### PR TITLE
Fix fm-sbt-s3-resolver not working for newer versions of JDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,12 @@ EclipseKeys.withSource := true
 // Don't use the default "target" directory (which is what SBT uses)
 EclipseKeys.eclipseOutput := Some(".target")
 
+val amazonSDKVersion = "1.10.35"
+
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.16",
-  "com.amazonaws" % "aws-java-sdk-sts" % "1.10.16",
+  "com.amazonaws" % "aws-java-sdk-s3" % amazonSDKVersion,
+  "com.amazonaws" % "aws-java-sdk-sts" % amazonSDKVersion,
+  "joda-time" % "joda-time" % "2.9.1" force(), //This is to fix https://github.com/aws/aws-sdk-java/issues/484
   "org.apache.ivy" % "ivy" % "2.3.0"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.9


### PR DESCRIPTION
Due to https://github.com/aws/aws-sdk-java/issues/484, fm-sbt-s3-resolver doesn't work for JDK versions newer than 1.8.0_45-b25.

This pull request fixes the issue by forcing a newer versions of JodaTime that works for newer versions of JDK