### PR TITLE
Fix the role-based provider credentials, need to use BasicSessionCredentials instead of BasicAWSCredentials, bump to 0.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fm-sbt-s3-resolver"
 
 organization := "com.frugalmechanic"
 
-version := "0.8.0"
+version := "0.8.1"
 
 description := "SBT S3 Resolver Plugin"
 

--- a/src/main/scala/fm/sbt/S3URLHandler.scala
+++ b/src/main/scala/fm/sbt/S3URLHandler.scala
@@ -91,7 +91,7 @@ object S3URLHandler {
 
       val result: AssumeRoleResult = securityTokenService.assumeRole(roleRequest)
 
-      new BasicAWSCredentials(result.getCredentials.getAccessKeyId, result.getCredentials.getSecretAccessKey)
+      new BasicSessionCredentials(result.getCredentials.getAccessKeyId, result.getCredentials.getSecretAccessKey, result.getCredentials.getSessionToken)
     }
 
     def refresh(): Unit = {}


### PR DESCRIPTION
@rmarsch can you look at this since you originally wrote it?  I wasn't able to get it to work until I made this change.

Works around the Exception: com.amazonaws.services.s3.model.AmazonS3Exception: The AWS Access Key Id you provided does not exist in our records. (Service: Amazon S3; Status Code: 403; Error Code: InvalidAccessKeyId; Request ID: 3DBCABD5610046E8), S3 Extended Request ID: E/wCcyt/1NicpJMyknKxxgsWGJuhYWboldq+H+tcnOtsf7vKi+5iKOyL6XBS6v4TPvEDkjzPBV0=

Based upon: http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
https://github.com/aws/aws-sdk-android/blob/78cdf680115a891a6e1355c56068e2f56e3c5056/aws-android-sdk-core/src/main/java/com/amazonaws/auth/STSAssumeRoleSessionCredentialsProvider.java#L200
and http://docs.aws.amazon.com/AmazonS3/latest/dev/AuthUsingTempSessionTokenJava.html