### PR TITLE
Add automatic support for S3 SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This SBT plugin adds support for using Amazon S3 for resolving and publishing us
   * [Usage](#usage)
   * [IAM Policy Examples](#iam)
   * [IAM Role Examples](#iam-role)
+  * [S3 Server-Side Encryption](#server-side-encryption)
   * [Authors](#authors)
   * [Copyright](#copyright)
   * [License](#license)
@@ -257,6 +258,47 @@ This is a simple example where a Host AWS Account, can create a Role with permis
 &nbsp;&nbsp;]
 }
 </pre>
+
+## <a name="server-side-encryption"></a>S3 Server-Side Encryption
+S3 supports <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">server side encryption</a>.
+The plugin will automatically detect if it needs to ask S3 to use SSE, based on the policies you have on your bucket. If
+your bucket denies `PutObject` requests that aren't using SSE, the plugin will include the SSE header in future requests.
+
+To make use of SSE, configure your bucket to enforce the SSE header for `PutObject` requests.
+
+Example:
+```json
+{
+  "Version": "2012-10-17",
+  "Id": "PutObjPolicy",
+  "Statement": [
+    {
+      "Sid": "DenyIncorrectEncryptionHeader",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_HERE/*",
+      "Condition": {
+        "StringNotEquals": {
+          "s3:x-amz-server-side-encryption": "AES256"
+        }
+      }
+    },
+    {
+      "Sid": "DenyUnEncryptedObjectUploads",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_HERE/*",
+      "Condition": {
+        "Null": {
+          "s3:x-amz-server-side-encryption": "true"
+        }
+      }
+    }
+  ]
+}
+```
 
 ## <a name="authors"></a>Authors
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fm-sbt-s3-resolver"
 
 organization := "com.frugalmechanic"
 
-version := "0.11.0-SNAPSHOT"
+version := "0.11.1-SNAPSHOT"
 
 description := "SBT S3 Resolver Plugin"
 

--- a/src/main/scala/fm/sbt/S3URLHandler.scala
+++ b/src/main/scala/fm/sbt/S3URLHandler.scala
@@ -17,23 +17,21 @@ package fm.sbt
 
 import java.io.{File, FileInputStream, InputStream}
 import java.net.{InetAddress, URI, URL}
-import java.util.{Properties, function}
+import java.util.Properties
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
 import com.amazonaws.{AmazonClientException, ClientConfiguration}
 import com.amazonaws.SDKGlobalConfiguration.{ACCESS_KEY_ENV_VAR, ACCESS_KEY_SYSTEM_PROPERTY, SECRET_KEY_ENV_VAR, SECRET_KEY_SYSTEM_PROPERTY}
 import com.amazonaws.auth._
-import com.amazonaws.regions.{Region, RegionUtils, Regions}
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client, AmazonS3URI}
 import com.amazonaws.services.securitytoken.{AWSSecurityTokenService, AWSSecurityTokenServiceClient}
 import com.amazonaws.services.securitytoken.model.{AssumeRoleRequest, AssumeRoleResult}
 import org.apache.ivy.util.url.URLHandler
 import org.apache.ivy.util.{CopyProgressEvent, CopyProgressListener, Message}
-import sbt.Resolver.url
 
 import scala.collection.JavaConverters._
-import scala.util.Try
 import scala.util.matching.Regex
 
 object S3URLHandler {


### PR DESCRIPTION
This checks to see if your bucket policies prevent the creation of unencrypted
files. If so, future PutObject requests will use the SSE request header.

This currently assumes you are using AWS KMS-managed encryption keys.