### PR TITLE
Fix Ivy publish example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Ivy Style:
 
 ```scala
 publishMavenStyle := false
-publishTo := Some("FrugalMechanic Snapshots" at "s3://maven.frugalmechanic.com/snapshots")
+publishTo := Some(Resolver.url("FrugalMechanic Snapshots", url("s3://maven.frugalmechanic.com/snapshots"))(Resolver.ivyStylePatterns))
 ```
 
 ### Valid s3:// URL Formats


### PR DESCRIPTION
The Ivy publish example in the readme ends up using maven style directory structure with Ivy XML descriptors. This is because the at syntax in SBT returns a `MavenRepository` rather than a simple resolver.

Doing it this way is also consistent with the syntax for resolution.